### PR TITLE
Update networkAndValidators_{es,en}.html

### DIFF
--- a/public/content/html/networkAndValidators_en.html
+++ b/public/content/html/networkAndValidators_en.html
@@ -17,7 +17,7 @@
           <td class="border px-4 py-2">The XRP Ledger, a decentralized cryptographic ledger powered by a network of peer-to-peer servers and the home of XRP.</td>
         </tr>
         <tr class="bg-gray-100">
-          <td class="border px-4 py-2">Tesnet</td>
+          <td class="border px-4 py-2">Testnet</td>
           <td class="border px-4 py-2">Stable releases</td>
           <td class="border px-4 py-2">An "alternate universe" network that acts as a testing ground for software built on the XRP Ledger.</td>
         </tr>

--- a/public/content/html/networkAndValidators_es.html
+++ b/public/content/html/networkAndValidators_es.html
@@ -17,7 +17,7 @@
           <td class="border px-4 py-2">The XRP Ledger, a decentralized cryptographic ledger powered by a network of peer-to-peer servers and the home of XRP.</td>
         </tr>
         <tr class="bg-gray-100">
-          <td class="border px-4 py-2">Tesnet</td>
+          <td class="border px-4 py-2">Testnet</td>
           <td class="border px-4 py-2">Stable releases</td>
           <td class="border px-4 py-2">An "alternate universe" network that acts as a testing ground for software built on the XRP Ledger.</td>
         </tr>


### PR DESCRIPTION
fix typo `Tesnet` ≫ `Testnet`